### PR TITLE
Remove references to jeoLayerTypes assets

### DIFF
--- a/src/includes/layer-types/class-layer-types.php
+++ b/src/includes/layer-types/class-layer-types.php
@@ -95,13 +95,7 @@ class Layer_Types {
 	}
 
 	public function register_assets() {
-		$asset_file = include( JEO_BASEPATH . '/js/build/jeoLayerTypes.asset.php');
-		//wp_register_script(
-		//	'jeo-layer-types',
-		//	JEO_BASEURL . '/js/build/JeoLayerTypes.js',
-		//	[],
-		//	$asset_file['version']
-		//);
+		$asset_file = include( JEO_BASEPATH . '/js/build/JeoLayer.asset.php');
 		wp_register_script(
 			'jeo-layer',
 			JEO_BASEURL . '/js/build/JeoLayer.js',


### PR DESCRIPTION
I see errors due to this reference and it seems like it should be loading `jeoLayer.asset.php` instead.