### PR TITLE
Force to always use 512 titles instead of 256, while loading style as raster

### DIFF
--- a/src/includes/layer-types/mapbox.js
+++ b/src/includes/layer-types/mapbox.js
@@ -27,7 +27,7 @@ window.JeoLayerTypes.registerLayerType( 'mapbox', {
 				tiles: [
 					'https://api.mapbox.com/styles/v1/' +
 						style_id +
-						'/tiles/256/{z}/{x}/{y}@2x?access_token=' +
+						'/tiles/512/{z}/{x}/{y}@2x?access_token=' +
 						accessToken,
 				],
 			},

--- a/src/js/src/map-blocks/map-preview-layer.js
+++ b/src/js/src/map-blocks/map-preview-layer.js
@@ -31,7 +31,7 @@ export function renderLayer( { layer, instance, onSourceLoadedCallback } ) {
 						tileJsonSource={ {
 							type: 'raster',
 							tiles: [
-								`https://api.mapbox.com/styles/v1/${ style_id }/tiles/256/{z}/{x}/{y}@2x?access_token=${ accessToken }`,
+								`https://api.mapbox.com/styles/v1/${ style_id }/tiles/512/{z}/{x}/{y}@2x?access_token=${ accessToken }`,
 							],
 						} }
 						onSourceLoaded={ () => {


### PR DESCRIPTION
# Front-end
## Before
![image](https://user-images.githubusercontent.com/7103838/109297695-2f672c80-7811-11eb-880a-026648451a58.png)
## After
![image](https://user-images.githubusercontent.com/7103838/109297735-3b52ee80-7811-11eb-9c79-520d3ed92e63.png)

# Admin
## Before
![image](https://user-images.githubusercontent.com/7103838/109298005-ae5c6500-7811-11eb-8b0d-83915e3e07a1.png)
## After
![image](https://user-images.githubusercontent.com/7103838/109298104-da77e600-7811-11eb-895a-ed5e3cf6ff39.png)


