### PR TITLE
Feature/panel position storymap

### DIFF
--- a/src/js/src/map-blocks/storymap-editor.js
+++ b/src/js/src/map-blocks/storymap-editor.js
@@ -384,49 +384,6 @@ const StoryMapEditor = ( {
 															}
 														} }
 													>
-														<span className="input-label">{ __( 'Title', 'jeo' ) }</span>
-														<CKEditor
-															atributo="meuatributo"
-															editor={ ClassicEditor }
-															data={ slide.title }
-															config={ editorConfig }
-															onChange={ ( event, editor ) => {
-																// Set role 'button' to editor element so it isn't affected by drag and drop events
-																editor.ui.getEditableElement().setAttribute('role', 'button')
-
-																setCurrentSlideIndex( index );
-
-																const oldSlides = [ ...attributes.slides ];
-																oldSlides[ index ].title = editor.getData();
-
-																setAttributes( {
-																	...attributes,
-																	slides: oldSlides,
-																} );
-															} }
-														/>
-														<span className="input-label">{ __(
-																'Content', 'jeo'
-														) }</span>
-														<CKEditor
-															editor={ ClassicEditor }
-															data={ slide.content }
-															config={ editorConfig }
-															onChange={ ( event, editor ) => {
-																// Set role 'button' to editor element so it isn't affected by drag and drop events
-																editor.ui.getEditableElement().setAttribute('role', 'button')
-
-																setCurrentSlideIndex( index );
-
-																const oldSlides = [ ...attributes.slides ];
-																oldSlides[ index ].content = editor.getData();
-
-																setAttributes( {
-																	...attributes,
-																	slides: oldSlides,
-																} );
-															} }
-														/>
 														<span className="input-label">{ __("Layers", "jeo") }</span>
 														<DragDropContext onDragEnd={ onDragEndLayers }>
 															<Droppable droppableId="droppable">
@@ -639,6 +596,50 @@ const StoryMapEditor = ( {
 																<span>{ __( 'Preview', 'jeo'  ) }</span>
 															</div>
 														</Button>
+
+														<span className="input-label">{ __( 'Title', 'jeo' ) }</span>
+														<CKEditor
+															atributo="meuatributo"
+															editor={ ClassicEditor }
+															data={ slide.title }
+															config={ editorConfig }
+															onChange={ ( event, editor ) => {
+																// Set role 'button' to editor element so it isn't affected by drag and drop events
+																editor.ui.getEditableElement().setAttribute('role', 'button')
+
+																setCurrentSlideIndex( index );
+
+																const oldSlides = [ ...attributes.slides ];
+																oldSlides[ index ].title = editor.getData();
+
+																setAttributes( {
+																	...attributes,
+																	slides: oldSlides,
+																} );
+															} }
+														/>
+														<span className="input-label">{ __(
+																'Content', 'jeo'
+														) }</span>
+														<CKEditor
+															editor={ ClassicEditor }
+															data={ slide.content }
+															config={ editorConfig }
+															onChange={ ( event, editor ) => {
+																// Set role 'button' to editor element so it isn't affected by drag and drop events
+																editor.ui.getEditableElement().setAttribute('role', 'button')
+
+																setCurrentSlideIndex( index );
+
+																const oldSlides = [ ...attributes.slides ];
+																oldSlides[ index ].content = editor.getData();
+
+																setAttributes( {
+																	...attributes,
+																	slides: oldSlides,
+																} );
+															} }
+														/>
 														<Button
 															className="remove-button"
 															onClick={ () => {

--- a/src/js/src/map-blocks/storymap-editor.scss
+++ b/src/js/src/map-blocks/storymap-editor.scss
@@ -88,6 +88,8 @@
 	position: absolute;
 	top: 50px;
 	padding: 10px;
+	left: calc(45% + 15px);
+	
 	.title {
 		label {
 			font-weight: bold;
@@ -115,6 +117,7 @@
 	bottom: 15%;
 	padding: 10px;
 	display: flex;
+	left: calc(45% + 15px);
 
 	// .section-title {
 	// 	margin: 0 0 0 15px;
@@ -147,7 +150,7 @@
 	padding: 10px;
 	position: absolute;
 	top: 50px;
-	left: calc(30% + 15px);
+	// left: calc(30% + 15px);
 	background-color: #fff;
 	.slide-panel {
 		border-left: none;
@@ -273,7 +276,7 @@
 .slides-settings-hide {
 	display: flex;
 	width: 45%;
-	left: calc(30% + 15px);
+	// left: calc(30% + 15px);
 	margin: 10px;
 	background-color: #fff;
 	position: absolute;

--- a/src/js/src/map-blocks/storymap-editor.scss
+++ b/src/js/src/map-blocks/storymap-editor.scss
@@ -89,7 +89,7 @@
 	top: 50px;
 	padding: 10px;
 	left: calc(45% + 15px);
-	
+
 	.title {
 		label {
 			font-weight: bold;
@@ -210,7 +210,7 @@
 		margin-top: 15px;
 		width: 100%;
 		background: rgb(240, 240, 240);
-		margin-top: 40px;
+
 		&:focus {
 			background: rgb(240, 240, 240);
 		}
@@ -228,7 +228,7 @@
 		}
 	}
 	.preview-button {
-		margin-top: 15px;
+		margin: 15px 0;
 		width: 100%;
 		background: rgb(240, 240, 240);
 		&:focus {

--- a/src/js/src/posts-sidebar/index.js
+++ b/src/js/src/posts-sidebar/index.js
@@ -4,6 +4,8 @@ import { Component, Fragment } from '@wordpress/element';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import JeoGeocodePosts from './geo-posts';
+import { useSelect } from '@wordpress/data';
+
 
 const JeoGeocodePanel = class JeoGeocodePanel extends Component {
 	constructor() {
@@ -38,10 +40,19 @@ const JeoGeocodePanel = class JeoGeocodePanel extends Component {
 registerPlugin( 'jeo-posts-sidebar', {
 	icon: null,
 	render: () => {
-		return (
-			<PluginDocumentSettingPanel title={ __( 'Geolocation', 'jeo' ) }>
-				<JeoGeocodePanel />
-			</PluginDocumentSettingPanel>
-		);
+
+	const currentPostType = useSelect( ( select ) => {
+		return select( 'core/editor' ).getCurrentPostType()
+	}, [] );
+
+	return (
+		<div>
+			{ currentPostType === "post" ? 
+				<PluginDocumentSettingPanel title={ __( 'Geolocation', 'jeo' ) }>
+					<JeoGeocodePanel />
+				</PluginDocumentSettingPanel>
+			: null };
+		</div>
+	)
 	},
 } );


### PR DESCRIPTION
## Reordenar painels

- [x]  Por "Configurações de slides" antes de "Configurações da história"

Nova ordem

![image](https://user-images.githubusercontent.com/12487823/115654250-21142900-a307-11eb-921d-fd76d4b0118c.png)

## Reordenar seções de "Configurações de slides" 

- [x] No toggle: Por "seleção de camadas" na 1eira posição.

Nova ordem do painel de cada slide
1. Seleção de camadas
2. Botões: Lock, Preview
3. Título
4. Descrição
5. Botão Remove

![image](https://user-images.githubusercontent.com/12487823/115656136-0479f000-a30b-11eb-9aaa-fa598d367d9a.png)

## StoryMap - remover geolocalizar

![image](https://user-images.githubusercontent.com/12487823/115669825-16658e00-a31f-11eb-99ff-2cae9dead090.png)

